### PR TITLE
fix: make pdb target all pods of the cluster

### DIFF
--- a/pkg/cluster/k8sres.go
+++ b/pkg/cluster/k8sres.go
@@ -2144,7 +2144,7 @@ func (c *Cluster) generatePodDisruptionBudget() *policyv1.PodDisruptionBudget {
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: c.roleLabelsSet(false, Master),
+				MatchLabels: c.labelsSet(false),
 			},
 		},
 	}

--- a/pkg/cluster/k8sres_test.go
+++ b/pkg/cluster/k8sres_test.go
@@ -2224,7 +2224,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: util.ToIntStr(1),
 					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"spilo-role": "master", "cluster-name": "myapp-database"},
+						MatchLabels: map[string]string{"cluster-name": "myapp-database"},
 					},
 				},
 			},
@@ -2248,7 +2248,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: util.ToIntStr(0),
 					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"spilo-role": "master", "cluster-name": "myapp-database"},
+						MatchLabels: map[string]string{"cluster-name": "myapp-database"},
 					},
 				},
 			},
@@ -2272,7 +2272,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: util.ToIntStr(0),
 					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"spilo-role": "master", "cluster-name": "myapp-database"},
+						MatchLabels: map[string]string{"cluster-name": "myapp-database"},
 					},
 				},
 			},
@@ -2296,7 +2296,7 @@ func TestGeneratePodDisruptionBudget(t *testing.T) {
 				Spec: policyv1.PodDisruptionBudgetSpec{
 					MinAvailable: util.ToIntStr(1),
 					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"spilo-role": "master", "cluster-name": "myapp-database"},
+						MatchLabels: map[string]string{"cluster-name": "myapp-database"},
 					},
 				},
 			},


### PR DESCRIPTION
fixes: https://github.com/zalando/postgres-operator/issues/1663

The PDB generated by the operator selects only the master pods. Because of this, it messes with the cluster autoscaler so it can never get rid of nodes. This PR changes the label selector for the PDB to include any pod part of the same cluster.